### PR TITLE
Dev

### DIFF
--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -61,7 +61,7 @@ echo "📦 Creating GitHub release for tag $TAG..."
  echo -e "${CYAN}📡 Creating GitHub release...${RESET}"
 
     RELEASE_RESPONSE=$(curl -s -X POST \
-        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "Authorization: Bearer ${TOKEN}" \
         -H "Accept: application/vnd.github+json" \
         https://api.github.com/repos/AnkanSaha/${REPO}/releases \
         -d "{
@@ -83,7 +83,7 @@ echo "📦 Creating GitHub release for tag $TAG..."
 
     echo -e "${CYAN}📦 Uploading .deb to GitHub release..."
     curl -s -X POST \
-        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "Authorization: Bearer ${TOKEN}" \
         -H "Content-Type: application/vnd.debian.binary-package" \
         --data-binary @"${DEB_FILE} \
         ""${UPLOAD_URL}"?name=${APP_NAME}"


### PR DESCRIPTION
This pull request includes a minor update to the `Scripts/release.sh` file, replacing the `GITHUB_TOKEN` variable with `TOKEN` for authorization headers in GitHub API requests.

* [`Scripts/release.sh`](diffhunk://#diff-b504dd8465f881c5baedb5683fba8156691e1be075907a1b971598d105f50a0aL64-R64): Updated the authorization header to use `${TOKEN}` instead of `${GITHUB_TOKEN}` in both the GitHub release creation and `.deb` file upload steps. [[1]](diffhunk://#diff-b504dd8465f881c5baedb5683fba8156691e1be075907a1b971598d105f50a0aL64-R64) [[2]](diffhunk://#diff-b504dd8465f881c5baedb5683fba8156691e1be075907a1b971598d105f50a0aL86-R86)